### PR TITLE
refactor: 다운로드 경로 서버 경로로 수정

### DIFF
--- a/dags/download_test_dag.py
+++ b/dags/download_test_dag.py
@@ -36,7 +36,7 @@ def extract(**context):
     chrome_options.add_argument("--headless")  # Headless 모드 설정
     chrome_options.add_argument("--download.default_directory=/downloads")
     chrome_options.add_experimental_option("prefs", {
-        "download.default_directory": "./",
+        "download.default_directory": "/home/ubuntu/airflow/downloads",
         "download.prompt_for_download": False,
         "download.directory_upgrade": True,
         "safebrowsing.enabled": True


### PR DESCRIPTION
### PR 타입
- 기능 수정

### 반영 브랜치
sojeong -> develop

### PR 설명
- 다운로드 경로를 /home/ubuntu/airflow/downloads로 변경