### PR TITLE
인프라 통합 테이블 생성 DAG 수정

### DIFF
--- a/dags/analytics_seoul_infra.py
+++ b/dags/analytics_seoul_infra.py
@@ -1,25 +1,74 @@
-from airflow import DAG
-from airflow.decorators import task
+from airflow.decorators import task, dag
 from airflow.providers.postgres.hooks.postgres import PostgresHook
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
+import psycopg2
+
+ANALYTICS_SCHEMA = "analytics"
+TEMP_TABLE = "temp_seoul_infra"
+MAIN_TABLE = "seoul_infra"
 
 # Redshift 연결 함수
 def get_redshift_connection(autocommit=True):
-    hook = PostgresHook(postgres_conn_id='redshift_dev')
+    hook = PostgresHook(postgres_conn_id="redshift_dev")
     conn = hook.get_conn()
     conn.autocommit = autocommit
-    return conn.cursor()
+    return conn
 
-# 임시 테이블 생성
-@task
-def create_temp_table():
-    cur = get_redshift_connection()
+
+# 쿼리문 실행시키는 함수
+def execute_query(query, parameters=None, autocommit=True, fetchall=False, executemany=False):
+    conn = get_redshift_connection(autocommit)
+    cur = conn.cursor()
     try:
-        create_query = """
-        DROP TABLE IF EXISTS analytics.temp_seoul_infra;
+        if not autocommit:
+            cur.execute("BEGIN;")
+        
+        if parameters:
+            if executemany:
+                cur.executemany(query, parameters)
+            else:
+                cur.execute(query, parameters)
+        else:
+            cur.execute(query)
+        
+        if not autocommit:
+            cur.execute("COMMIT;")
+        
+        if fetchall:
+            return cur.fetchall()
+    except psycopg2.DatabaseError as db_error:
+        logging.error(f"Database error: {db_error}")
+        cur.execute("ROLLBACK;")
+        raise
+    except Exception as error:
+        print(f"execute query failed {error}, {type(error)}")
+        cur.execute("ROLLBACK;")
+        raise
+    finally:
+        cur.close()
+        conn.close()
 
-        CREATE TABLE analytics.temp_seoul_infra (
+
+@dag(
+    start_date=datetime(2024, 7, 10),
+    catchup=False,
+    tags=["analytics", "infra"],
+    default_args={
+        "owner": "kain",
+        "retries": 2,
+        "retry_delay": timedelta(minutes=5),
+    }
+)
+def analytics_seoul_infra():
+
+    # 테이블 생성
+    @task
+    def create_temp_table():
+        create_query = f"""
+        DROP TABLE IF EXISTS {ANALYTICS_SCHEMA}.{TEMP_TABLE};
+
+        CREATE TABLE {ANALYTICS_SCHEMA}.{TEMP_TABLE} (
             id INT IDENTITY(1, 1) PRIMARY KEY,
             category VARCHAR(50),
             name VARCHAR(100),
@@ -29,135 +78,117 @@ def create_temp_table():
             longitude FLOAT,
             district_name VARCHAR(30),
             legal_dong_name VARCHAR(30),
-            subject_code VARCHAR(50) DEFAULT NULL 
+            culture_subject VARCHAR(50) DEFAULT NULL 
         );
         """
-        cur.execute(create_query)
-    except Exception as e:
-        logging.error(f"Error creating table: {e}")
+        execute_query(create_query)
 
-# 데이터 삽입
-@task
-def insert_data():
-    cur = get_redshift_connection(False)
-    try:
+
+    # 데이터 삽입
+    @task
+    def insert_data():
+        # (category, {컬럼명 매핑}, 테이블명)
+        # key: 통합 테이블의 컬럼 이름, value: 각각의 테이블의 컬럼 이름
         tables = [
-            # (category, (컬럼명 매핑), (테이블명))
-            # key: 통합 테이블의 컬럼 이름, value: 원본 테이블의 컬럼 이름
-            # detailed_address와 subject_code는 모든 테이블에 있는 컬럼이 아니므로 NULL값 처리
             ("문화시설", {
-                'name': 'name',
-                'address': 'address',
-                'detailed_address': 'NULL',
-                'latitude': 'lat',
-                'longitude': 'lon',
-                'district_name': 'district_name',
-                'legal_dong_name': 'legal_dong_name',
-                'subject_code': 'subject_code'
+                "name": "name",
+                "address": "address",
+                "detailed_address": "NULL",
+                "latitude": "latitude",
+                "longitude": "longitude",
+                "district_name": "district_name",
+                "legal_dong_name": "legal_dong_name",
+                "culture_subject": "culture_subject"
             }, "analytics.seoul_culture"),
             ("병원", {
-                'name': 'name',
-                'address': 'address',
-                'detailed_address': 'NULL',
-                'latitude': 'lat',
-                'longitude': 'lon',
-                'district_name': 'district_name',
-                'legal_dong_name': 'legal_dong_name',
-                'subject_code': 'NULL'
+                "name": "name",
+                "address": "address",
+                "detailed_address": "NULL",
+                "latitude": "lat",
+                "longitude": "lon",
+                "district_name": "district_name",
+                "legal_dong_name": "legal_dong_name",
+                "culture_subject": "NULL"
             }, "analytics.seoul_hospital"),
             ("어린이집", {
-                'name': 'kindergarden_name',
-                'address': 'road_address',
-                'detailed_address': 'NULL',
-                'latitude': 'latitude',
-                'longitude': 'longitude',
-                'district_name': 'district_name',
-                'legal_dong_name': 'legal_dong_name',
-                'subject_code': 'NULL'
+                "name": "kindergarden_name",
+                "address": "road_address",
+                "detailed_address": "NULL",
+                "latitude": "latitude",
+                "longitude": "longitude",
+                "district_name": "district_name",
+                "legal_dong_name": "legal_dong_name",
+                "culture_subject": "NULL"
             }, "analytics.seoul_kindergarden"),
             ("학원", {
-                'name': 'academy_name',
-                'address': 'road_address',
-                'detailed_address': 'detailed_road_address',
-                'latitude': 'latitude',
-                'longitude': 'longitude',
-                'district_name': 'district_name',
-                'legal_dong_name': 'legal_dong_name',
-                'subject_code': 'NULL'
+                "name": "academy_name",
+                "address": "road_address",
+                "detailed_address": "detailed_road_address",
+                "latitude": "latitude",
+                "longitude": "longitude",
+                "district_name": "district_name",
+                "legal_dong_name": "legal_dong_name",
+                "culture_subject": "NULL"
             }, "raw_data.seoul_academy"),
             ("영화관", {
-                'name': 'screen_name',
-                'address': 'road_address',
-                'detailed_address': 'NULL',
-                'latitude': 'latitude',
-                'longitude': 'longitude',
-                'district_name': 'district_name',
-                'legal_dong_name': 'legal_dong_name',
-                'subject_code': 'NULL'
-            }, "raw_data.seoul_cinema"),
+                "name": "screen_name",
+                "address": "road_address",
+                "detailed_address": "NULL",
+                "latitude": "latitude",
+                "longitude": "longitude",
+                "district_name": "district_name",
+                "legal_dong_name": "legal_dong_name",
+                "culture_subject": "NULL"
+            }, "analytics.seoul_cinema"),
             ("공원", {
-                'name': 'park_name',
-                'address': 'address',
-                'detailed_address': 'NULL',
-                'latitude': 'latitude',
-                'longitude': 'longitude',
-                'district_name': 'district_name',
-                'legal_dong_name': 'legal_dong_name',
-                'subject_code': 'NULL'
+                "name": "park_name",
+                "address": "address",
+                "detailed_address": "NULL",
+                "latitude": "latitude",
+                "longitude": "longitude",
+                "district_name": "district_name",
+                "legal_dong_name": "legal_dong_name",
+                "culture_subject": "NULL"
             }, "raw_data.seoul_park"),
             ("학교", {
-                'name': 'school_name',
-                'address': 'road_address',
-                'detailed_address': 'detailed_road_address',
-                'latitude': 'latitude',
-                'longitude': 'longitude',
-                'district_name': 'district_name',
-                'legal_dong_name': 'legal_dong_name',
-                'subject_code': 'NULL'
-            }, "raw_data.seoul_school")
+                "name": "school_name",
+                "address": "road_address",
+                "detailed_address": "detailed_road_address",
+                "latitude": "latitude",
+                "longitude": "longitude",
+                "district_name": "district_name",
+                "legal_dong_name": "legal_dong_name",
+                "culture_subject": "NULL"
+            }, "analytics.seoul_school")
         ]
         
-        cur.execute("BEGIN;")
         for category, column_mapping, table_location in tables:
-            values = ', '.join([col for col in column_mapping.values()])
+            values = ", ".join([col for col in column_mapping.values()])
             
             insert_query = f"""
-            INSERT INTO analytics.temp_seoul_infra (category, name, address, detailed_address, latitude, longitude, district_name, legal_dong_name, subject_code)
-            SELECT 
-                '{category}' AS category,
-                {values}
-            FROM {table_location};
+            INSERT INTO {ANALYTICS_SCHEMA}.{TEMP_TABLE} (category, name, address, detailed_address, latitude, longitude, district_name, legal_dong_name, culture_subject)
+            SELECT '{category}' AS category, {values}
+            FROM {table_location}
+            WHERE (district_name <> '') AND
+                (legal_dong_name IS NOT NULL) AND
+                (legal_dong_name <> '');
             """
-            cur.execute(insert_query)
-        
-        cur.execute("COMMIT;")
-    except Exception as e:
-        logging.error(f"Error inserting data: {e}")
-        cur.execute("ROLLBACK;")
-        raise
+            execute_query(insert_query, autocommit=False)
 
-# 테이블 교체
-@task
-def swap_tables():
-    cur = get_redshift_connection(False)
-    try:
-        cur.execute("BEGIN;")
-        cur.execute("DROP TABLE IF EXISTS analytics.seoul_infra;")
-        cur.execute("ALTER TABLE analytics.temp_seoul_infra RENAME TO seoul_infra;")
-        cur.execute("COMMIT;")
-    except Exception as e:
-        logging.error(f"Error swapping tables: {e}")
-        cur.execute("ROLLBACK;")
 
-# DAG 정의
-with DAG(
-    dag_id='analytics_seoul_infra',
-    start_date=datetime(2024, 8, 1),
-    schedule_interval='0 6 * * 6',  # 한국 기준 토요일 오후 3시
-    catchup=False
-) as dag:
+    # 테이블 이름 변경 
+    @task
+    def rename_table():
+        rename_query = f"""
+        DROP TABLE IF EXISTS {ANALYTICS_SCHEMA}.{MAIN_TABLE};
+        ALTER TABLE {ANALYTICS_SCHEMA}.{TEMP_TABLE} RENAME TO {MAIN_TABLE};
+        """
+        execute_query(rename_query, autocommit=False)
+
     create_temp_table_task = create_temp_table()
     insert_data_task = insert_data()
-    swap_tables_task = swap_tables()
+    rename_table_task = rename_table()
 
-    create_temp_table_task >> insert_data_task >> swap_tables_task
+    create_temp_table_task >> insert_data_task >> rename_table_task
+
+analytics_seoul_infra()


### PR DESCRIPTION
## PR 내용
- 인프라 통합 테이블 생성하는 DAG 수정
- 인프라 관련 테이블의 구조가 바뀜에 따라 매핑 컬럼명 및 테이블명 수정
- 코드 구조 변경
    - 상수처리
    - execute_query 함수화
    - DAG에 owner, tags 정보 추가

## 기능 설명
1. 테이블 생성 
    - analytics에 seoul_infra의 이름으로 테이블 생성
2. 데이터 삽입
    - 학교, 학원, 어린이집, 병원, 영화관, 공원, 문화시설에 대한 데이터 통합 
    - 주요하게 쓰일 지역구/행정동명 데이터가 비어있는 행은 제외시킴

## 로컬 실행 화면
![image](https://github.com/user-attachments/assets/6d87b8cc-f5d6-4168-879f-40c7c0f70a42)
![image](https://github.com/user-attachments/assets/a90657d0-6dd5-4792-b17b-14fc2ebf0810)
