### PR TITLE
서울 인프라 통합 dag 트리거 추가

### DIFF
--- a/dags/infra_trigger.py
+++ b/dags/infra_trigger.py
@@ -1,0 +1,72 @@
+from airflow.decorators import dag
+from airflow.operators.trigger_dagrun import TriggerDagRunOperator
+from airflow.sensors.external_task import ExternalTaskSensor
+from datetime import datetime, timedelta
+
+@dag(
+    start_date=datetime(2024, 1, 1),
+    catchup=False,
+    tags=["trigger"],
+    default_args={
+        "owner": "kain",
+    }
+)
+def infra_trigger():
+    sensor_culture = ExternalTaskSensor(
+        task_id='wait_for_dag_culture',
+        external_dag_id='analytics_seoul_culture',  
+        mode='reschedule',
+        timeout=7200,  
+        poke_interval=600   
+    )
+
+    sensor_academy = ExternalTaskSensor(
+        task_id='wait_for_dag_academy',
+        external_dag_id='seoul_academy',
+        mode='reschedule',
+        timeout=7200,  
+        poke_interval=600   
+    )
+
+    sensor_cinema = ExternalTaskSensor(
+        task_id='wait_for_dag_cinema',
+        external_dag_id='seoul_cinema',
+        mode='reschedule',
+        timeout=7200,  
+        poke_interval=600   
+    )
+
+    sensor_kindergarden = ExternalTaskSensor(
+        task_id='wait_for_dag_kindergarden',
+        external_dag_id='seoul_kindergarden',
+        mode='reschedule',
+        timeout=7200,  
+        poke_interval=600   
+    )
+
+    sensor_park = ExternalTaskSensor(
+        task_id='wait_for_dag_park',
+        external_dag_id='seoul_park',
+        mode='reschedule',
+        timeout=7200,  
+        poke_interval=600   
+    )
+
+    sensor_school = ExternalTaskSensor(
+        task_id='wait_for_dag_school',
+        external_dag_id='seoul_school',
+        mode='reschedule',
+        timeout=7200,  
+        poke_interval=600   
+    )
+
+    # 서울 인프라 통합 dag 트리거
+    trigger_next_dag = TriggerDagRunOperator(
+        task_id='trigger_infra_dag',
+        trigger_dag_id='analytics_seoul_infra'  
+    )
+
+    # 서울 인프라 dag가 모두 끝나면 서울 인프라 통합 dag 실행
+    [sensor_culture, sensor_academy, sensor_cinema, sensor_kindergarden, sensor_park, sensor_school] >> trigger_next_dag
+
+infra_trigger()


### PR DESCRIPTION
## PR 내용
- 서울 인프라 관련 여러 DAG(analytics_seoul_culture, seoul_academy, seoul_cinema, seoul_kindergarden, seoul_park, seoul_school)의 실행 상태를 모니터링하는 infra_trigger DAG을 추가

## 내용 설명
![image](https://github.com/user-attachments/assets/1879dbd0-741a-438b-9610-82c4c34b958a)
- ExternalTaskSensor를 사용하여 실행 주기가 같은 서울 인프라 DAG의 실행 상태를 감시합니다.
    - 아래의 dag는 모두 토요일 오전 10시(9시 50)에 실행
    - analytics_seoul_culture
    - seoul_academy
    - seoul_cinema
    - seoul_kindergarden
    - seoul_park
    - seoul_school
- 2시간 동안 실행상태를 감시하며 10분마다 체크하도로 설정
- 모든 외부 DAG의 실행이 완료되면, TriggerDagRunOperator를 통해 analytics_seoul_infra DAG를 트리거